### PR TITLE
Make sink-logger attribute of QueueListener publicly accessible

### DIFF
--- a/examples/joblib_.py
+++ b/examples/joblib_.py
@@ -1,4 +1,5 @@
 import sys
+import time
 
 from joblib import Parallel, delayed
 from loguru import logger
@@ -10,27 +11,45 @@ from loguru_parallel import (
 )
 
 if __name__ == "__main__":
-    loguru_enqueue_and_listen(handlers=[dict(sink=sys.stderr)])
+    listener = loguru_enqueue_and_listen(handlers=[dict(sink=sys.stderr)])
     logger.info("Starting")
-
-    def _test_patcher(record):
-        record["message"] = record["message"] + " (with patcher)"
-
-    logger.configure(patcher=_test_patcher)
 
     worker_func = propagate_logger(worker_func, logger)
     funcs = [delayed(worker_func)(x) for x in range(3)]
 
-    logger.info("Loky")
+    logger.configure(
+        patcher=lambda record: record.update(
+            {"message": record["message"] + " (from Loky)"}
+        )
+    )
     Parallel(n_jobs=4, backend="loky")(funcs)
 
-    logger.info("Multiprocessing")
+    logger.configure(
+        patcher=lambda record: record.update(
+            {"message": record["message"] + " (from Multiprocessing)"}
+        )
+    )
     Parallel(n_jobs=4, backend="multiprocessing")(funcs)
 
-    logger.info("Threading")
+    logger.configure(
+        patcher=lambda record: record.update(
+            {"message": record["message"] + " (from Threading)"}
+        )
+    )
     Parallel(n_jobs=4, backend="threading")(funcs)
 
-    logger.info("Sequential")
-    Parallel(n_jobs=1, backend="sequential")(funcs)
+    # Change logging configuration
+    time.sleep(0.5)
+    listener.sink_logger.remove()
+    listener.sink_logger.add(sys.stdout, serialize=True)
+    logger.configure(extra={"extra_key": "extra_value"})
 
+    logger.configure(
+        patcher=lambda record: record.update(
+            {"message": record["message"] + " (from Sequential)"}
+        )
+    )
+    Parallel(n_jobs=4, backend="sequential")(funcs)
+
+    logger.configure(patcher=lambda record: record)
     logger.info("Finished")

--- a/src/loguru_parallel/enqueue.py
+++ b/src/loguru_parallel/enqueue.py
@@ -16,8 +16,8 @@ def create_log_queue() -> Queue:
 def enqueue_logger(queue: Queue) -> None:
     """Configure the loguru.logger instance to send logs to a queue.
 
-    This means that all handlers are deleted and replaced with a single handler that
-    enqueues records log queue passed to this function.
+    This means that all handlers are removed and replaced with a single handler
+    that enqueues records to the queue.
     """
     logger.remove()
 
@@ -30,13 +30,13 @@ def enqueue_logger(queue: Queue) -> None:
 
 
 def logger_is_enqueued(logger) -> bool:
-    """Check whether all handlers of the logger are enqueued.
+    """Check whether the logger is enqueued.
 
     Args:
         logger: The loguru logger instance to check.
 
     Returns:
-        True if all handlers are enqueued, False otherwise.
+        True if the logger has a single enqueued handler, False otherwise.
     """
     handlers = logger._core.handlers
     if len(handlers) != 1:

--- a/src/loguru_parallel/listen.py
+++ b/src/loguru_parallel/listen.py
@@ -36,6 +36,11 @@ class LoguruQueueListener(QueueListener):
         atexit.register(sink_logger.remove)
         self._sink_logger = sink_logger
 
+    @property
+    def sink_logger(self):
+        """Public access to the logger instance that logs to the sink."""
+        return self._sink_logger
+
     def handle(self, record):
         """Logs a record from the queue."""
         record = record.record


### PR DESCRIPTION
Making `LoguruQueueListener.sink_logger` accessible through a property, to allow changing the configuration of the sink logger.