### PR TITLE
ci: bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
 


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v5 (v4 uses Node 20)
- `actions/setup-python` v5 → v6 (v5 uses Node 20)

Both are runtime-only bumps with no breaking changes. Ahead of the 2026-06-16 GitHub Actions runner default switch to Node 24.

Ref: MLE-828 · [Node 20→24 Migration Playbook](https://www.notion.so/37248474eb3b81449694c39db78b0e27)

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)